### PR TITLE
Fix category prompt counts

### DIFF
--- a/category-manager.js
+++ b/category-manager.js
@@ -169,7 +169,22 @@ class CategoryManager {
 
     getPromptCount(categoryId) {
         if (!window.promptManager) return 0;
-        return window.promptManager.prompts.filter(p => p.category === categoryId).length;
+        const allCategories = [categoryId, ...this.getAllDescendantCategories(categoryId)];
+        return window.promptManager.prompts.filter(p => allCategories.includes(p.category)).length;
+    }
+
+    getAllDescendantCategories(categoryId) {
+        const descendants = [];
+        const category = this.categories.find(c => c.id === categoryId);
+
+        if (category && category.children) {
+            category.children.forEach(childId => {
+                descendants.push(childId);
+                descendants.push(...this.getAllDescendantCategories(childId));
+            });
+        }
+
+        return descendants;
     }
 
     getCategoryPath(categoryId) {


### PR DESCRIPTION
## Summary
- account for all sub-categories when counting prompts in a category
- add recursive `getAllDescendantCategories` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d81828a70832ebc49bfc7990a8516