### PR TITLE
Update card styles

### DIFF
--- a/app.js
+++ b/app.js
@@ -241,10 +241,11 @@ class PromptManager {
 
     createPromptCard(prompt) {
         const categoryPath = categoryManager.getCategoryPath(prompt.category);
+        const categoryColor = categoryManager.getCategoryColor(prompt.category);
         const createdDate = new Date(prompt.created).toLocaleDateString('de-DE');
 
         return `
-            <div class="prompt-card">
+            <div class="prompt-card" style="border-top-color: ${categoryColor};">
                 <div class="prompt-card-header">
                     <h3 ondblclick="promptManager.showFullDescription(${prompt.id})">${prompt.title}</h3>
                 </div>

--- a/category-manager.js
+++ b/category-manager.js
@@ -203,6 +203,11 @@ class CategoryManager {
 
         return path.join(' > ');
     }
+
+    getCategoryColor(categoryId) {
+        const category = this.categories.find(c => c.id === categoryId);
+        return category ? category.color : '#ccc';
+    }
 }
 
 // Global functions

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,7 @@ button:hover {
   border-radius: 12px;
   box-shadow: var(--shadow);
   transition: all 0.2s ease;
+  border-top: 10px solid transparent;
   overflow: hidden;
 }
 
@@ -208,8 +209,8 @@ button:hover {
 
 .prompt-card-header {
   padding: 16px;
-  background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-  color: white;
+  background: var(--card-bg);
+  color: var(--text-primary);
 }
 
 .prompt-card-header h3 {
@@ -244,8 +245,8 @@ button:hover {
 }
 
 .tag {
-  background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-  color: white;
+  background: #e0e0e0;
+  color: var(--text-primary);
   padding: 4px 10px;
   border-radius: 12px;
   font-size: 0.8em;


### PR DESCRIPTION
## Summary
- keep card headers white instead of using gradient colors
- highlight card top borders with the category color
- show tags on grey backgrounds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d95b8f100832e942001cff13f7db3