### PR TITLE
Add collapsible category tree

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -160,9 +160,35 @@ button:hover {
   border-radius: 6px;
   cursor: pointer;
   transition: background 0.2s ease;
+}
+
+.category-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 6px;
+}
+
+.toggle-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 14px;
+  transition: transform 0.2s ease;
+}
+
+.toggle-btn.open {
+  transform: rotate(90deg);
+}
+
+.subcategories {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease;
+}
+
+.subcategories.open {
+  max-height: 1000px;
 }
 
 .category-item:hover {


### PR DESCRIPTION
## Summary
- enable storing open state for categories in `CategoryManager`
- add toggle button support and event handling in `buildTreeHTML`
- save open state to `localStorage`
- animate collapse/expand via new CSS classes

## Testing
- `node --check category-manager.js`

------
https://chatgpt.com/codex/tasks/task_e_684da3af032c832ea10a3be6858807bb