### PR TITLE
Add ESC key global close feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Analysiere den {{datentyp}} für {{unternehmen}}:
 ## 💡 Tipps & Tricks
 
 ### Effiziente Nutzung
-- **Keyboard-Shortcuts**: ESC schließt alle Dialoge
+- **Keyboard-Shortcuts**: ESC schließt geöffnete Dialoge und das Modal
 - **Bulk-Import**: Mehrere Prompts gleichzeitig importieren
 - **Backup-Routine**: Regelmäßig exportieren für Datensicherheit
 - **Tag-System**: Konsistente Tags für bessere Auffindbarkeit

--- a/app.js
+++ b/app.js
@@ -489,3 +489,14 @@ function closeTemplateDialog() {
 window.addEventListener('DOMContentLoaded', () => {
     window.promptManager = new PromptManager();
 });
+
+// Global keydown handler to close dialogs and modal with ESC
+document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+        document.querySelectorAll('dialog[open]').forEach(d => d.close());
+        const overlay = document.getElementById('modalOverlay');
+        if (overlay && overlay.classList.contains('show')) {
+            overlay.classList.remove('show');
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- allow closing all dialogs and modal with Escape key
- mention Escape shortcut in the README

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_684da3b811b4832e9db6776e14281385