### PR TITLE
Add dark mode option

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ class PromptManager {
         this.currentView = 'grid';
         this.editingPromptId = null;
 
+        this.applySavedTheme();
         this.initEventListeners();
         this.renderPrompts();
         categoryManager.updateCategorySelects();
@@ -64,6 +65,7 @@ class PromptManager {
         document.getElementById('categoriesBtn').addEventListener('click', () => this.showCategoryDialog());
         document.getElementById('toggleViewBtn').addEventListener('click', () => this.toggleView());
         document.getElementById('newPromptBtn').addEventListener('click', () => this.showPromptDialog());
+        document.getElementById('themeToggle').addEventListener('click', () => this.toggleTheme());
 
         // Import/Export
         document.getElementById('exportBtn').addEventListener('click', () => this.exportData());
@@ -327,6 +329,27 @@ class PromptManager {
         }
 
         this.renderPrompts();
+    }
+
+    toggleTheme() {
+        const isDark = document.body.classList.toggle('dark-theme');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        this.updateThemeToggleText();
+    }
+
+    applySavedTheme() {
+        const saved = localStorage.getItem('theme');
+        if (saved === 'dark') {
+            document.body.classList.add('dark-theme');
+        }
+        this.updateThemeToggleText();
+    }
+
+    updateThemeToggleText() {
+        const btn = document.getElementById('themeToggle');
+        if (!btn) return;
+        const isDark = document.body.classList.contains('dark-theme');
+        btn.textContent = isDark ? '☀️ Helles Theme' : '🌙 Dunkles Theme';
     }
 
     searchPrompts(term) {

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
                 <button id="categoriesBtn">📁 Kategorien</button>
                 <button id="toggleViewBtn">📊 Tabellenansicht</button>
                 <button id="dashboardBtn" onclick="window.location.href='dashboard.html'">📈 Dashboard</button>
+                <button id="themeToggle">🌙 Dunkles Theme</button>
                 <div class="dropdown">
                     <button id="menuBtn">⚙️ Menü</button>
                     <div class="dropdown-content">

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,22 @@
   --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
+/* Dark theme overrides */
+body.dark-theme {
+  --primary-color: #0a84ff;
+  --secondary-color: #5e5ce6;
+  --success-color: #30d158;
+  --warning-color: #ffd60a;
+  --danger-color: #ff453a;
+  --background-color: #1c1c1e;
+  --card-bg: #2c2c2e;
+  --border-color: #3a3a3c;
+  --text-primary: #f2f2f7;
+  --text-secondary: #d1d1d6;
+  --shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+  --shadow-lg: 0 8px 20px rgba(0, 0, 0, 0.8);
+}
+
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- define CSS variables for a dark theme and toggle with `body.dark-theme`
- add a theme toggle button to the header
- implement theme switching logic with localStorage persistence

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684da3b51070832ea94c0cac79a83add